### PR TITLE
Potential fix for code scanning alert no. 6: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/common/src/main/java/space/ranzeplay/saysth/config/ConfigManager.java
+++ b/common/src/main/java/space/ranzeplay/saysth/config/ConfigManager.java
@@ -100,11 +100,16 @@ public class ConfigManager {
             while (entries.hasMoreElements()) {
                 var entry = entries.nextElement();
                 if (entry.getName().startsWith("assets/professions/") && entry.getName().endsWith(".txt")) {
-                    var targetFile = getProfessionPath().resolve(entry.getName().substring("assets/professions/".length())).toFile();
+                    var targetPath = getProfessionPath().resolve(entry.getName().substring("assets/professions/".length())).normalize();
+                    if (!targetPath.startsWith(getProfessionPath())) {
+                        Main.LOGGER.warn("Skipping invalid entry: {}", entry.getName());
+                        continue;
+                    }
+                    var targetFile = targetPath.toFile();
                     if (!targetFile.exists()) {
                         var stream = getClass().getResourceAsStream("/" + entry.getName());
                         assert stream != null;
-                        Files.copy(stream, targetFile.toPath());
+                        Files.copy(stream, targetPath);
                         stream.close();
                     }
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/Ranzeplay/saysth/security/code-scanning/6](https://github.com/Ranzeplay/saysth/security/code-scanning/6)

To fix the issue, we need to validate the resolved path of the target file to ensure it is within the intended directory (`getProfessionPath()`). This can be achieved by:
1. Normalizing the resolved path of the target file using `toPath().normalize()`.
2. Verifying that the normalized path starts with the intended directory path (`getProfessionPath()`).
3. Throwing an exception or skipping the entry if the validation fails.

This ensures that even if the archive entry contains malicious directory traversal sequences, the application will not write files outside the intended directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
