### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,6 +5,8 @@
 
 name: build
 on: [pull_request, push]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/Ranzeplay/saysth/security/code-scanning/2](https://github.com/Ranzeplay/saysth/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily involves building and packaging artifacts, it likely only needs `contents: read` permission to access the repository files. We will add the `permissions` block at the root level of the workflow to apply it to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
